### PR TITLE
New build changes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,12 @@ crate-type = ["lib"]
 path = "./ioreg"
 
 [dependencies.rlibc]
-version = "*"
+git = "https://github.com/posborne/rlibc.git"
+branch = "test-libcore-dependency"
+
+[dependencies.core]
+git = "https://github.com/posborne/rust-libcore.git"
+branch = "rust-1.0.0"
 
 [[example]]
 name = "blink"

--- a/Makefile
+++ b/Makefile
@@ -36,5 +36,5 @@ $(EXAMPLE_NAME).lst: $(EXAMPLE_FILE)
 	$(OBJDUMP) -D $< > $@
 
 $(ISR_FILE): $(ISR_SRC)
-	rustc --target=$(TARGET) --emit=obj --cfg mcu_$(PLATFORM) -C opt-level=2 $<
+	rustc --verbose -L target/$(TARGET)/debug/deps --target=$(TARGET) --emit=obj --cfg mcu_$(PLATFORM) -C opt-level=2 $<
 	$(STRIP) -N rust_begin_unwind -N rust_stack_exhausted -N rust_eh_personality $@

--- a/examples/app_blink.rs
+++ b/examples/app_blink.rs
@@ -1,60 +1,37 @@
-#![feature(plugin, no_std, core)]
-#![crate_type="staticlib"]
+#![feature(no_std, core, start)]
 #![no_std]
-#![plugin(macro_platformtree)]
 
 extern crate core;
 extern crate zinc;
-#[macro_use] #[no_link] extern crate macro_platformtree;
 
-platformtree!(
-  lpc17xx@mcu {
-    clock {
-      source = "main-oscillator";
-      source_frequency = 12_000_000;
-      pll {
-        m = 50;
-        n = 3;
-        divisor = 4;
-      }
+use zinc::hal::timer::Timer;
+use zinc::hal::lpc17xx::{pin, timer};
+use zinc::hal::pin::GpioDirection;
+use zinc::hal::pin::Gpio;
+use core::option::Option::Some;
+
+#[start]
+fn start(_: isize, _: *const *const u8) -> isize {
+    main();
+    0
+}
+
+pub fn main() {
+    zinc::hal::mem_init::init_stack();
+    zinc::hal::mem_init::init_data();
+    
+    // P1.20 => LED-2 (mbed LPC1768)
+    let led2 = pin::Pin::new(
+        pin::Port::Port1, 21,
+        pin::Function::Gpio,
+        Some(GpioDirection::Out));
+
+    let timer = timer::Timer::new(timer::TimerPeripheral::Timer0, 25, 4);
+    
+    loop  {
+        led2.set_high();
+        timer.wait_ms(10);
+        led2.set_low();
+        timer.wait_ms(10);
     }
-
-    timer {
-      timer@1 {
-        counter = 25;
-        divisor = 4;
-      }
-    }
-
-    gpio {
-      1 {
-        led1@18 { direction = "out"; }
-        led2@20 { direction = "out"; }
-      }
-    }
-  }
-
-  os {
-    single_task {
-      loop = "run";
-      args {
-        timer = &timer;
-        led1 = &led1;
-        led2 = &led2;
-      }
-    }
-  }
-);
-
-fn run(args: &pt::run_args) {
-  use zinc::hal::pin::Gpio;
-  use zinc::hal::timer::Timer;
-
-  args.led1.set_high();
-  args.led2.set_low();
-  args.timer.wait(1);
-
-  args.led1.set_low();
-  args.led2.set_high();
-  args.timer.wait(1);
 }


### PR DESCRIPTION
This is mostly just for discussion and to let you know how things have gone for me so far.
- I am able to get an LED to blink on the LPC1768 I have... Yay!
- Here's what I have to do to build currently
  - `cargo build --verbose --target=thumbv7m-none-eabi` (runs  and eventually fails with `dylib outputs are not supported for thumbv7m-none-eabi` but it pulls down and builds dependnecies as expected
  - `PLATFORM=lpc17xx EXAMPLE_NAME=blink make build`.  Runs but fails on linking due to the files being mixed in the middle of the link command with the options
  - Run manual gcc command to link
  - Run make again

Here's the link failure I see...

```
error: linking with `arm-none-eabi-gcc` failed: exit code: 1
note: "arm-none-eabi-gcc" "-L" "/usr/local/lib/rustlib/thumbv7m-none-eabi/lib" "-o" "/home/posborne/Projects/rust-playground/zinc/target/thumbv7m-none-eabi/release/examples/blink" "/home/posborne/Projects/rust-playground/zinc/target/thumbv7m-none-eabi/release/examples/blink.o" "-Wl,--gc-sections" "-Wl,-O1" "-nodefaultlibs" "/home/posborne/Projects/rust-playground/zinc/target/thumbv7m-none-eabi/release/libzinc.rlib" "/home/posborne/Projects/rust-playground/zinc/target/thumbv7m-none-eabi/release/deps/librlibc-bc645030eede58dd.rlib" "/home/posborne/Projects/rust-playground/zinc/target/thumbv7m-none-eabi/release/deps/libcore-5fa36418cfb46fb4.rlib" "-L" "/home/posborne/Projects/rust-playground/zinc/target/thumbv7m-none-eabi/release" "-L" "/home/posborne/Projects/rust-playground/zinc/target/thumbv7m-none-eabi/release/deps" "-L" "/usr/local/lib/rustlib/thumbv7m-none-eabi/lib" "-L" "/home/posborne/Projects/rust-playground/zinc/.rust/lib/thumbv7m-none-eabi" "-L" "/home/posborne/Projects/rust-playground/zinc/lib/thumbv7m-none-eabi" "-Wl,--whole-archive" "-Wl,-Bstatic" "-Wl,--no-whole-archive" "-Wl,-Bdynamic" "-mthumb" "-mcpu=cortex-m3" "-Tsrc/hal/lpc17xx/layout.ld" "-lm" "-lgcc" "isr.o"
note: /usr/lib/gcc/arm-none-eabi/4.8.2/armv7-m/libgcc.a(unwind-arm.o): In function `__aeabi_unwind_cpp_pr0':
/build/buildd/gcc-arm-none-eabi-6/build/arm-none-eabi/armv7-m/libgcc/../../../../gcc-4.8.2/libgcc/config/arm/unwind-arm.c:494: multiple definition of `__aeabi_unwind_cpp_pr0'
/home/posborne/Projects/rust-playground/zinc/target/thumbv7m-none-eabi/release/libzinc.rlib(zinc.o):zinc.0.rs:(.text.__aeabi_unwind_cpp_pr0+0x0): first defined here
collect2: error: ld returned 1 exit status
```

And the working link command:

```
"arm-none-eabi-gcc" \                         
  "-L" "/usr/local/lib/rustlib/thumbv7m-none-eabi/lib" \
  "-o" "/home/posborne/Projects/rust-playground/zinc/target/thumbv7m-none-eabi/release/examples/blink" \
  "-Wl,--gc-sections" "-Wl,-O1" "-nodefaultlibs" \
  "-L" "/home/posborne/Projects/rust-playground/zinc/target/thumbv7m-none-eabi/release" \
  "-L" "/home/posborne/Projects/rust-playground/zinc/target/thumbv7m-none-eabi/release/deps" \
  "-L" "/usr/local/lib/rustlib/thumbv7m-none-eabi/lib" \
  "-L" "/home/posborne/Projects/rust-playground/zinc/.rust/lib/thumbv7m-none-eabi" \
  "-L" "/home/posborne/Projects/rust-playground/zinc/lib/thumbv7m-none-eabi" \
  "-Wl,--whole-archive" "-Wl,-Bstatic" "-Wl,--no-whole-archive" "-Wl,-Bdynamic" \
  "-mthumb" "-mcpu=cortex-m3" "-Tsrc/hal/lpc17xx/layout.ld" "-lm" "-lgcc" \
  "/home/posborne/Projects/rust-playground/zinc/target/thumbv7m-none-eabi/release/examples/blink.o" \
  "/home/posborne/Projects/rust-playground/zinc/target/thumbv7m-none-eabi/release/libzinc.rlib" \
  "/home/posborne/Projects/rust-playground/zinc/target/thumbv7m-none-eabi/release/deps/librlibc-bc645030eede58dd.rlib" \
  "/home/posborne/Projects/rust-playground/zinc/target/thumbv7m-none-eabi/release/deps/libcore-5fa36418cfb46fb4.rlib" \
  "isr.o"
```
