### PR TITLE
Provide zinc_main annotation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,9 @@ path = "./platformtree"
 [dev-dependencies.macro_platformtree]
 path = "./macro_platformtree"
 
+[dev-dependencies.macro_zinc]
+path = "./macro_zinc"
+
 [[example]]
 name = "nothing"
 path = "examples/app_nothing.rs"

--- a/examples/app_blink.rs
+++ b/examples/app_blink.rs
@@ -1,5 +1,6 @@
-#![feature(no_std, core, start)]
+#![feature(plugin, no_std, core, start)]
 #![no_std]
+#![plugin(macro_zinc)]
 
 extern crate core;
 extern crate zinc;
@@ -10,12 +11,7 @@ use zinc::hal::pin::GpioDirection;
 use zinc::hal::pin::Gpio;
 use core::option::Option::Some;
 
-#[start]
-fn start(_: isize, _: *const *const u8) -> isize {
-  main();
-  0
-}
-
+#[zinc_main]
 pub fn main() {
   zinc::hal::mem_init::init_stack();
   zinc::hal::mem_init::init_data();

--- a/examples/app_blink_k20.rs
+++ b/examples/app_blink_k20.rs
@@ -1,5 +1,6 @@
-#![feature(no_std, core, start)]
+#![feature(plugin, no_std, core, start)]
 #![no_std]
+#![plugin(macro_zinc)]
 
 extern crate core;
 extern crate zinc;
@@ -24,6 +25,7 @@ pub fn wait(ticks: u32) {
   }
 }
 
+#[zinc_main]
 pub fn main() {
   zinc::hal::mem_init::init_stack();
   zinc::hal::mem_init::init_data();
@@ -40,10 +42,4 @@ pub fn main() {
     led1.set_low();
     wait(10);
   }
-}
-
-#[start]
-fn start(_: isize, _: *const *const u8) -> isize {
-  main();
-  0
 }

--- a/examples/app_blink_stm32f4.rs
+++ b/examples/app_blink_stm32f4.rs
@@ -1,5 +1,6 @@
-#![feature(no_std, core, start)]
+#![feature(plugin, no_std, core, start)]
 #![no_std]
+#![plugin(macro_zinc)]
 
 extern crate core;
 extern crate zinc;
@@ -7,12 +8,7 @@ extern crate zinc;
 use zinc::hal::timer::Timer;
 use zinc::hal::stm32f4::{pin, timer};
 
-#[start]
-fn start(_: isize, _: *const *const u8) -> isize {
-  main();
-  0
-}
-
+#[zinc_main]
 pub fn main() {
   zinc::hal::mem_init::init_stack();
   zinc::hal::mem_init::init_data();

--- a/examples/app_blink_stm32l1.rs
+++ b/examples/app_blink_stm32l1.rs
@@ -1,15 +1,11 @@
-#![feature(no_std, core, start)]
+#![feature(plugin, no_std, core, start)]
 #![no_std]
+#![plugin(macro_zinc)]
 
 extern crate core;
 extern crate zinc;
 
-#[start]
-fn start(_: isize, _: *const *const u8) -> isize {
-  main();
-  0
-}
-
+#[zinc_main]
 pub unsafe fn main() {
   use core::option::Option;
   use zinc::hal::pin::Gpio;

--- a/examples/app_nothing.rs
+++ b/examples/app_nothing.rs
@@ -1,13 +1,9 @@
-#![feature(no_std, core, start)]
+#![feature(plugin, no_std, core, start)]
 #![no_std]
+#![plugin(macro_zinc)]
 
 extern crate zinc;
 
-#[start]
-fn start(_: isize, _: *const *const u8) -> isize {
-  main();
-  0
-}
-
+#[zinc_main]
 pub fn main() {
 }

--- a/examples/app_usart_stm32l1.rs
+++ b/examples/app_usart_stm32l1.rs
@@ -1,16 +1,12 @@
-#![feature(no_std, core, start)]
+#![feature(plugin, no_std, core, start)]
 #![no_std]
+#![plugin(macro_zinc)]
 
 extern crate core;
 extern crate zinc;
 
-#[start]
-fn start(_: isize, _: *const *const u8) -> isize {
-  main();
-  0
-}
-
-pub unsafe fn main() {
+#[zinc_main]
+pub fn main() {
   use zinc::drivers::chario::CharIO;
   use zinc::hal;
   use zinc::hal::pin::Gpio;

--- a/macro_zinc/Cargo.toml
+++ b/macro_zinc/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "macro_zinc"
+version = "0.1.0"
+authors = ["Matt Coffin <mcoffin13@gmail.com>"]
+
+[lib]
+name = "macro_zinc"
+plugin = true

--- a/macro_zinc/src/lib.rs
+++ b/macro_zinc/src/lib.rs
@@ -1,0 +1,46 @@
+#![feature(rustc_private, plugin_registrar, quote)]
+
+extern crate rustc;
+extern crate syntax;
+
+use rustc::plugin::Registry;
+use syntax::ast::MetaItem;
+use syntax::codemap::{Span, DUMMY_SP};
+use syntax::ext::base::{Annotatable, ExtCtxt, MultiDecorator};
+use syntax::ext::build::AstBuilder;
+
+macro_rules! and_return {
+    ($a:stmt) => (
+        {
+            $a;
+            return;
+        }
+    )
+}
+
+#[plugin_registrar]
+pub fn plugin_registrar(reg: &mut Registry) {
+    reg.register_syntax_extension(syntax::parse::token::intern("zinc_main"),
+                                  MultiDecorator(Box::new(decorator_zinc_main)));
+}
+
+pub fn decorator_zinc_main(cx: &mut ExtCtxt,
+                           sp: Span,
+                           _: &MetaItem,
+                           item: &Annotatable,
+                           push: &mut FnMut(Annotatable)) {
+    let main = match item {
+        &Annotatable::Item(ref main_item) => (*main_item).ident,
+        _ => and_return!(cx.span_err(sp, "zinc_main must be an item")),
+    };
+
+    let call_main = cx.expr_call_ident(DUMMY_SP, main, Vec::new());
+    let start = quote_item!(cx,
+        #[start]
+        fn start(_: isize, _: *const *const u8) -> isize {
+            $call_main;
+            0
+        }
+    ).unwrap();
+    push(Annotatable::Item(start));
+}


### PR DESCRIPTION
This removes the need for the boilerplate `#[start]` code in examples and dependents of zinc in favor of a very simple decorator style annotation based syntax extension.
